### PR TITLE
fix: include "extensions" files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "node": ">=6"
   },
   "files": [
-    "bin"
+    "bin",
+    "scripts"
   ],
   "bin": {
     "build-pocket": "./bin/run.js"


### PR DESCRIPTION
`bin/run.js` is referencing the files in the `extensions` directory but 
the files are not part after a `npm install` OR `yarn install`.
With this change the "extensions" files are included.

Fixes the following error: 

```
pocket-build-tools/bin/run.js:38:19

Error: Cannot find module '../extensions/save-to-pocket/scripts/start'
```

Related issue: https://github.com/Pocket/extension-save-to-pocket/issues/18